### PR TITLE
feature: add setting to optionally use shorthand category link

### DIFF
--- a/djangocms_stories/settings.py
+++ b/djangocms_stories/settings.py
@@ -621,6 +621,13 @@ STORIES_WIZARD_CONTENT_PLUGIN_BODY = "body"
 Name of the plugin field to add wizard text.
 """
 
+STORIES_USE_SHORTHAND_CATEGORY_LINK = False
+"""
+.. _USE_SHORTHAND_CATEGORY_LINK
+
+Wether to use "c" or "category" for the category urls.
+"""
+
 params = {param: value for param, value in locals().items() if param.startswith("STORIES_")}
 
 """

--- a/djangocms_stories/urls.py
+++ b/djangocms_stories/urls.py
@@ -12,11 +12,13 @@ from .views import (
     TaggedListView,
 )
 
+_category_snippet = "c" if get_setting("USE_SHORTHAND_CATEGORY_LINK") is True else "category"
+
 app_name = "djangocms_stories"
 urlpatterns = [
     path("", PostListView.as_view(), name="posts-latest"),
-    path("category/", CategoryListView.as_view(), name="categories-all"),
-    path("category/<str:category>/", CategoryEntriesView.as_view(), name="posts-category"),
+    path(f"{_category_snippet}/", CategoryListView.as_view(), name="categories-all"),
+    path(f"{_category_snippet}/<str:category>/", CategoryEntriesView.as_view(), name="posts-category"),
     path("feed/", LatestEntriesFeed(), name="posts-latest-feed"),
     path("feed/fb/", FBInstantArticles(), name="posts-latest-feed-fb"),
     path("<int:year>/", PostArchiveView.as_view(), name="posts-archive"),


### PR DESCRIPTION
possible solution for #25 

-> using a setting to toggle default or shorthand links für category urls.