### PR TITLE
fix: Features post plugin stayed empty

### DIFF
--- a/djangocms_stories/cms_plugins.py
+++ b/djangocms_stories/cms_plugins.py
@@ -93,7 +93,7 @@ class BlogFeaturedPostsPlugin(StoriesPlugin):
     def render(self, context, instance, placeholder):
         """Render the plugin."""
         context = super().render(context, instance, placeholder)
-        context["posts_list"] = instance.get_posts(context["request"])
+        context["postcontent_list"] = instance.get_posts(context["request"])
         context["TRUNCWORDS_COUNT"] = get_setting("POSTS_LIST_TRUNCWORDS_COUNT")
         return context
 

--- a/djangocms_stories/models.py
+++ b/djangocms_stories/models.py
@@ -683,7 +683,11 @@ class BasePostPlugin(CMSPlugin):
 
     def post_content_queryset(self, request=None, selected_posts=None):
         language = translation.get_language()
-        if request and getattr(request, "toolbar", False) and request.toolbar.edit_mode_active:
+        if (
+            request
+            and getattr(request, "toolbar", False)
+            and (request.toolbar.edit_mode_active or request.toolbar.preview_mode_active)
+        ):
             post_contents = PostContent.admin_manager.latest_content()
         else:
             post_contents = PostContent.objects.all()

--- a/djangocms_stories/models.py
+++ b/djangocms_stories/models.py
@@ -782,7 +782,12 @@ class FeaturedPostsPlugin(BasePostPlugin):
         self,
         request,
     ):
-        return self.post_content_queryset(request, selected_posts=self.posts.all())
+        posts = self.posts.all()
+        map = {
+            post_content.post_id: post_content
+            for post_content in self.post_content_queryset(request, selected_posts=posts)
+        }
+        return [map.get(post.pk) for post in posts if post.pk in map]
 
 
 class GenericBlogPlugin(BasePostPlugin):

--- a/djangocms_stories/models.py
+++ b/djangocms_stories/models.py
@@ -374,7 +374,7 @@ class Post(models.Model):
 
     def __str__(self):
         default = gettext("Post (no translation)")
-        return self.safe_translation_getter("title", any_language=True, default=default)
+        return self.safe_translation_getter("title", any_language=True, default=default, show_draft_content=True)
 
     @admin.display(boolean=True)
     def featured(self):

--- a/djangocms_stories/templates/djangocms_stories/plugins/featured_posts.html
+++ b/djangocms_stories/templates/djangocms_stories/plugins/featured_posts.html
@@ -1,8 +1,8 @@
 {% load i18n %}{% spaceless %}
 <div class="plugin plugin-blog">
     <div class="blog-featured-posts">
-        {% for post in posts_list %}
-            {% include "djangocms_stories/includes/post_item.html" with post=post image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
+        {% for post_content in postcontent_list %}
+            {% include "djangocms_stories/includes/post_item.html" with post_content=post_content image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
         {% endfor %}
     </div>
 </div>

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -100,14 +100,12 @@ def test_blog_featured_posts_plugin(placeholder, admin_client, simple_w_placehol
     instance.posts.add(*[post_content.post for post_content in batch if random.choice([True, False])])
     instance.posts.add(batch[0].post)  # Ensure at least one post is featured
     featured = instance.posts.all()
-
     url = get_object_preview_url(placeholder.source)
 
     response = admin_client.get(url)
     assert_html_in_response("<p>TextPlugin works.</p>", response)
-
     for post_content in batch:
-        if post_content in featured:
+        if post_content.post in featured:
             assert_html_in_response(
                 post_content.title,
                 response,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -123,7 +123,7 @@ def test_blog_featured_posts_plugin(placeholder, admin_client, simple_w_placehol
         from django.test import Client
 
         # No posts are published yet, so the featured posts should not appear on the site
-        url = placeholder.source.get_absolute_url()
+        url = placeholder.source.get_absolute_url("en")
         response = Client().get(url)
 
         assert response.status_code == 200


### PR DESCRIPTION
## Summary by Sourcery

Fix the Featured Posts plugin to correctly render posts and integrate with djangocms-versioning, and add tests for unpublished content handling

Bug Fixes:
- Correct the context key from posts_list to postcontent_list in the plugin and template to restore featured posts rendering
- Fix test logic to check membership against post_content.post rather than post_content

Enhancements:
- Include preview_mode_active alongside edit_mode_active for versioned content in post_content_queryset

Tests:
- Use the PUBLISHED constant in tests for versioned content setup
- Add a test case to verify unpublished posts are not displayed on the frontend when versioning is enabled

fixes #47