### PR TITLE
fix: Allow for request-based site detection

### DIFF
--- a/djangocms_blog/managers.py
+++ b/djangocms_blog/managers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 
 from django.contrib.contenttypes.models import ContentType

--- a/djangocms_stories/cms_menus.py
+++ b/djangocms_stories/cms_menus.py
@@ -59,14 +59,15 @@ class PostCategoryMenu(CMSAttachMenu):
 
         used_categories = []
         if posts_menu:
+            site = get_current_site(request)
             if getattr(request, "toolbar", False) and request.toolbar.edit_mode_active:
-                post_contents = PostContent.admin_manager.current_content(language=language).on_site()
+                post_contents = PostContent.admin_manager.current_content(language=language).on_site(site)
             else:
                 post_contents = PostContent.objects.filter(language=language)
             if hasattr(self, "instance") and self.instance:
                 post_contents = post_contents.filter(
                     post__app_config__namespace=self.instance.application_namespace
-                ).on_site()
+                ).on_site(site)
             post_contents = (
                 post_contents.distinct()
                 .select_related("post", "post__app_config")

--- a/djangocms_stories/managers.py
+++ b/djangocms_stories/managers.py
@@ -56,11 +56,11 @@ class TaggedFilterItem:
         queryset = self.tag_list(other_model, queryset)
         return queryset.values("slug")
 
-    def tag_cloud(self, other_model=None, queryset=None, published=True, on_site=False):
+    def tag_cloud(self, other_model=None, queryset=None, published: bool = True, site: Site | None = None):
         from taggit.models import TaggedItem
 
-        if on_site:
-            queryset = queryset.on_site()
+        if site:
+            queryset = queryset.on_site(site)
         tag_ids = self._taglist(other_model, queryset)
         kwargs = {}
         if published:
@@ -82,14 +82,12 @@ class TaggedFilterItem:
 
 
 class SiteQuerySet(models.QuerySet):
-    def on_site(self, site=None):
-        if not site:
-            site = Site.objects.get_current()
+    def on_site(self, site: Site) -> "SiteQuerySet":
         return self.filter(models.Q(post__sites__isnull=True) | models.Q(post__sites=site.pk))
 
-    def filter_by_language(self, language, current_site=True):
-        if current_site:
-            return self.filter(language=language).on_site()
+    def filter_by_language(self, language, site: Site | None = None) -> "SiteQuerySet":
+        if site:
+            return self.filter(language=language).on_site(site)
         else:
             return self.filter(language=language)
 
@@ -143,21 +141,21 @@ class GenericDateTaggedManager(TaggedFilterItem, models.Manager):
     def archived(self, current_site=True):
         return self.get_queryset().archived(current_site)
 
-    def filter_by_language(self, language, current_site=True):
-        return self.get_queryset().filter_by_language(language, current_site)
+    def filter_by_language(self, language, site: Site | None = None):
+        return self.get_queryset().filter_by_language(language, site)
 
     def on_site(self, site=None):
         return self.get_queryset().on_site(site)
 
-    def get_months(self, queryset=None, current_site=True):
+    def get_months(self, queryset=None, site: Site | None = None):
         """
         Get months with aggregate count (how many posts is in the month).
         Results are ordered by date.
         """
         if queryset is None:
             queryset = self.get_queryset()
-        if current_site:
-            queryset = queryset.on_site()
+        if site:
+            queryset = queryset.on_site(site)
         dates_qs = queryset.values_list(self.start_date_field, self.fallback_date_field)
         dates = []
         for blog_dates in dates_qs:

--- a/djangocms_stories/managers.py
+++ b/djangocms_stories/managers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 
 from django.contrib.contenttypes.models import ContentType
@@ -82,14 +84,8 @@ class TaggedFilterItem:
 
 
 class SiteQuerySet(models.QuerySet):
-    def on_site(self, site: Site) -> "SiteQuerySet":
+    def on_site(self, site: Site) -> SiteQuerySet:
         return self.filter(models.Q(post__sites__isnull=True) | models.Q(post__sites=site.pk))
-
-    def filter_by_language(self, language, site: Site | None = None) -> "SiteQuerySet":
-        if site:
-            return self.filter(language=language).on_site(site)
-        else:
-            return self.filter(language=language)
 
 
 class AdminSiteQuerySet(SiteQuerySet):
@@ -131,18 +127,6 @@ class GenericDateTaggedManager(TaggedFilterItem, models.Manager):
 
     def get_queryset(self, *args, **kwargs):
         return self.queryset_class(model=self.model, using=self._db, hints=self._hints)
-
-    def published_on_rss(self, current_site=True):
-        return self.get_queryset().published_on_rss(current_site)
-
-    def available(self, current_site=True):
-        return self.get_queryset().available(current_site)
-
-    def archived(self, current_site=True):
-        return self.get_queryset().archived(current_site)
-
-    def filter_by_language(self, language, site: Site | None = None):
-        return self.get_queryset().filter_by_language(language, site)
 
     def on_site(self, site=None):
         return self.get_queryset().on_site(site)

--- a/djangocms_stories/utils.py
+++ b/djangocms_stories/utils.py
@@ -1,5 +1,7 @@
 from django.apps import apps
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
 
 _versioning_enabled = None if "djangocms_versioning" in settings.INSTALLED_APPS else False
 
@@ -16,3 +18,18 @@ def is_versioning_enabled():
         except LookupError:
             _versioning_enabled = False
     return _versioning_enabled
+
+
+def site_compatibility_decorator(func):
+    """
+    A decorator to provide compatibility for django CMS versions
+    that do not support request-aware get_current_site calls.
+    """
+
+    try:
+        func(None)
+    except TypeError:
+        return lambda request: func()
+    except ImproperlyConfigured:
+        return func
+    return func

--- a/djangocms_stories/views.py
+++ b/djangocms_stories/views.py
@@ -10,11 +10,17 @@ from django.utils.translation import get_language
 from django.views.generic import DetailView, ListView
 from parler.views import TranslatableSlugMixin, ViewUrlMixin
 
+from cms.utils import get_current_site
+
 from .cms_appconfig import get_app_instance
 from .models import PostCategory, PostContent
 from .settings import get_setting
+from .utils import site_compatibility_decorator
+
 
 User = get_user_model()
+
+get_current_site = site_compatibility_decorator(get_current_site)
 
 
 class StoriesConfigMixin:
@@ -117,7 +123,8 @@ class BaseConfigListViewMixin(StoriesConfigMixin):
             queryset = self.model.objects.all()
         queryset = queryset.filter(language=language, post__app_config__namespace=self.namespace)
         setattr(self.request, get_setting("CURRENT_NAMESPACE"), self.config)
-        return self.optimize(queryset.on_site())
+        site = get_current_site(self.request)
+        return self.optimize(queryset.on_site(site))
 
     def get_template_names(self):
         template_path = (self.config and self.config.template_prefix) or "djangocms_stories"

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -232,10 +232,21 @@ class TestGenericDateTaggedManager:
 
     def test_get_months_with_current_site(self, page_with_menu, many_posts):
         """Test get_months filters by current site"""
-        site = Site.objects.get_current()
-        months = Post.objects.get_months(site=site)
+        # Ensure at least one date has two posts
+        first = Post.objects.first()
+        first.date_featured = Post.objects.last().date_featured
+        first.save()
 
+        months = Post.objects.get_months()
         assert isinstance(months, list)
+        # Assert that each month in the result matches posts from the specified site
+        for month in months:
+            date, count = month["date"], month["count"]
+            posts_in_month = Post.objects.filter(
+                date_featured__month=date.month,
+                date_featured__year=date.year,
+            )
+            assert posts_in_month.count() == count
 
     def test_get_months_without_current_site(self, page_with_menu, many_posts):
         """Test get_months without site filtering"""

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -205,7 +205,7 @@ class TestGenericDateTaggedManager:
 
     def test_on_site_manager(self, page_with_menu, many_posts):
         """Test manager-level on_site method"""
-        posts = Post.objects.on_site()
+        posts = Post.objects.on_site(Site.objects.get_current())
 
         assert posts.exists()
 
@@ -232,13 +232,14 @@ class TestGenericDateTaggedManager:
 
     def test_get_months_with_current_site(self, page_with_menu, many_posts):
         """Test get_months filters by current site"""
-        months = Post.objects.get_months(current_site=True)
+        site = Site.objects.get_current()
+        months = Post.objects.get_months(site=site)
 
         assert isinstance(months, list)
 
     def test_get_months_without_current_site(self, page_with_menu, many_posts):
         """Test get_months without site filtering"""
-        months = Post.objects.get_months(current_site=False)
+        months = Post.objects.get_months(site=None)
 
         assert isinstance(months, list)
 
@@ -296,7 +297,8 @@ class TestManagerIntegration:
 
     def test_combining_filters(self, page_with_menu, many_posts):
         """Test combining manager methods with Django ORM filters"""
-        posts = Post.objects.on_site().filter(pk__in=[many_posts[0].post.pk])
+        site = Site.objects.get_current()
+        posts = Post.objects.on_site(site).filter(pk__in=[many_posts[0].post.pk])
 
         assert posts.count() >= 0
 
@@ -304,7 +306,8 @@ class TestManagerIntegration:
         """Test combining manager methods with Django ORM filters"""
         post = many_posts[0].post
 
-        posts = Post.objects.on_site().filter(pk=post.pk)
+        site = Site.objects.get_current()
+        posts = Post.objects.on_site(site).filter(pk=post.pk)
 
         assert posts.count() == 1
         assert posts.first() == post
@@ -326,8 +329,9 @@ class TestManagerIntegration:
         post.tags.add("site-tag")
 
         # Get tag cloud for current site
-        qs = Post.objects.on_site()
-        cloud = Post.objects.tag_cloud(queryset=qs, on_site=True, published=False)
+        site = Site.objects.get_current()
+        qs = Post.objects.all()
+        cloud = Post.objects.tag_cloud(queryset=qs, site=site, published=False)
 
         assert isinstance(cloud, list)
 


### PR DESCRIPTION
## Summary by Sourcery

Enable explicit site-based filtering throughout Story models and utilities by accepting a Site instance in manager methods and ensuring compatibility with various django CMS versions.

Enhancements:
- Refactor tag_cloud, SiteQuerySet.on_site, filter_by_language, and get_months methods to accept a Site instance instead of a boolean flag
- Introduce site_compatibility_decorator to adapt get_current_site for older and newer django CMS versions
- Update view mixins and CMS menu integration to retrieve the current site from request and pass it to on_site calls

Tests:
- Revise existing tests to pass explicit Site objects to on_site and get_months methods
- Adjust tag_cloud tests to use the new site parameter for site-based filtering