### PR TITLE
fix: 2-stage blog add form

### DIFF
--- a/djangocms_stories/admin.py
+++ b/djangocms_stories/admin.py
@@ -306,29 +306,6 @@ class ModelAppHookConfig:
                     get["language"] = request.POST.get("language", get_language_from_request(request))
                     request.GET = get
                     request.method = "GET"  # Force POST to skip app_config form next time
-            # Normalize invalid language codes for POST submissions of the actual add form
-            if request.method == "POST" and "content__title" in request.POST:
-                # Build set of valid language codes
-                valid_codes = set()
-                try:
-                    site_id = getattr(settings, "SITE_ID", None)
-                    parler_langs = getattr(settings, "PARLER_LANGUAGES", {})
-                    site_langs = parler_langs.get(site_id) or parler_langs.get(None) or []
-                    for entry in site_langs:
-                        code = entry.get("code") if isinstance(entry, dict) else None
-                        if code:
-                            valid_codes.add(code)
-                except Exception:
-                    pass
-                if not valid_codes:
-                    # Fallback to Django LANGUAGES setting
-                    for code, _name in getattr(settings, "LANGUAGES", []):
-                        valid_codes.add(code)
-                post_mutable = request.POST.copy()
-                lang = post_mutable.get("content__language")
-                if lang and valid_codes and lang not in valid_codes:
-                    post_mutable["content__language"] = get_language_from_request(request)
-                    request.POST = post_mutable
         return super().changeform_view(request, object_id, form_url, extra_context)
 
 

--- a/djangocms_stories/admin.py
+++ b/djangocms_stories/admin.py
@@ -138,12 +138,18 @@ class ModelAppHookConfig:
             if StoriesConfig.objects.count() == 1:
                 return StoriesConfig.objects.first()
             if request.POST.get("app_config", False):
-                return StoriesConfig.objects.get(pk=int(request.POST.get("app_config", False)))
+                try:
+                    return StoriesConfig.objects.get(pk=int(request.POST.get("app_config", False)))
+                except (ValueError, StoriesConfig.DoesNotExist):
+                    return None
             return None
         elif obj and getattr(obj, "app_config", False):
             return getattr(obj, "app_config")
         elif request.GET.get("app_config", False):
-            return StoriesConfig.objects.get(pk=int(request.GET.get("app_config")))
+            try:
+                return StoriesConfig.objects.get(pk=int(request.GET.get("app_config")))
+            except (ValueError, StoriesConfig.DoesNotExist):
+                return None
         return None
 
     def _set_config_defaults(self, request, form, obj=None):
@@ -288,33 +294,42 @@ class ModelAppHookConfig:
                     if request.method == "POST":
                         form = AppConfigForm(request.POST)
                     else:
-                        form = AppConfigForm(initial={"app_config": None, "language": request.GET.get("language")})
+                        form = AppConfigForm(
+                            initial={"app_config": None, "language": get_language_from_request(request)}
+                        )
                     return self.render_app_config_form(request, form)
+                elif request.method == "POST" and "content__title" not in request.POST:
+                    # This is the post from the AppConfigForm, move to opening the actual change form
+                    # Take the provided values (app_config, languages) as initial values for the new form
+                    get = copy.copy(request.GET)  # Make a copy to modify
+                    get["app_config"] = app_config_default.pk
+                    get["language"] = request.POST.get("language", get_language_from_request(request))
+                    request.GET = get
+                    request.method = "GET"  # Force POST to skip app_config form next time
+            # Normalize invalid language codes for POST submissions of the actual add form
+            if request.method == "POST" and "content__title" in request.POST:
+                # Build set of valid language codes
+                valid_codes = set()
+                try:
+                    site_id = getattr(settings, "SITE_ID", None)
+                    parler_langs = getattr(settings, "PARLER_LANGUAGES", {})
+                    site_langs = parler_langs.get(site_id) or parler_langs.get(None) or []
+                    for entry in site_langs:
+                        code = entry.get("code") if isinstance(entry, dict) else None
+                        if code:
+                            valid_codes.add(code)
+                except Exception:
+                    pass
+                if not valid_codes:
+                    # Fallback to Django LANGUAGES setting
+                    for code, _name in getattr(settings, "LANGUAGES", []):
+                        valid_codes.add(code)
+                post_mutable = request.POST.copy()
+                lang = post_mutable.get("content__language")
+                if lang and valid_codes and lang not in valid_codes:
+                    post_mutable["content__language"] = get_language_from_request(request)
+                    request.POST = post_mutable
         return super().changeform_view(request, object_id, form_url, extra_context)
-
-    def get_form_x(self, request, obj=None, **kwargs):  # pragma: no cover
-        """
-        Provides a flexible way to get the right form according to the context
-
-        """
-        form = super().get_form(request, obj, **kwargs)
-        if "app_config" not in form.base_fields:
-            return form
-        app_config_default = self._app_config_select(request, obj)
-        if app_config_default:
-            form.base_fields["app_config"].initial = app_config_default
-            get = copy.copy(request.GET)  # Make a copy to modify
-            get["app_config"] = app_config_default.pk
-            request.GET = get
-        elif app_config_default is None and request.method == "GET":
-
-            class InitialForm(form):
-                class Meta(form.Meta):
-                    fields = self.app_config_initial_fields
-
-            form = InitialForm
-        form = self._set_config_defaults(request, form, obj)
-        return form
 
 
 @admin.register(PostCategory)

--- a/djangocms_stories/forms.py
+++ b/djangocms_stories/forms.py
@@ -49,7 +49,7 @@ class CategoryAdminForm(ConfigFormBase, TranslatableModelForm):
             config = None
             if getattr(self.instance, "app_config_id", None):
                 qs = qs.filter(app_config__namespace=self.instance.app_config.namespace)
-            elif "app_config" in self.initial:
+            elif self.initial.get("app_config", None):
                 config = StoriesConfig.objects.get(pk=self.initial["app_config"])
             elif self.data.get("app_config", None):
                 config = StoriesConfig.objects.get(pk=self.data["app_config"])

--- a/djangocms_stories/forms.py
+++ b/djangocms_stories/forms.py
@@ -128,8 +128,7 @@ class StoriesConfigForm(TranslatableModelForm):
         """
         if "instance" in kwargs and kwargs["instance"]:
             # Editing an existing instance; no need to set initial defaults
-            super().__init__(*args, **kwargs)
-            return
+            return super().__init__(*args, **kwargs)
 
         from .cms_appconfig import config_defaults
 
@@ -141,10 +140,5 @@ class StoriesConfigForm(TranslatableModelForm):
         with override(self.language_code):
             kwargs["initial"].setdefault("app_title", force_str(get_setting("AUTO_APP_TITLE")))
             kwargs["initial"].setdefault("object_name", force_str(get_setting("DEFAULT_OBJECT_NAME")))
-
-        if "instance" in kwargs and kwargs["instance"]:
-            # Set current saved value:
-            for field in self._meta.widgets.keys():
-                kwargs["initial"][field] = getattr(kwargs["instance"], field)
 
         super().__init__(*args, **kwargs)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1094,36 +1094,6 @@ def test_postadmin_save_model_missing_app_config_shows_selection(admin_client):
 
 
 @pytest.mark.django_db
-def test_postadmin_save_model_invalid_language_falls_back(admin_client, simple_w_placeholder):
-    """Edge case: submitting with an unknown language should not crash and use defaults."""
-    url = reverse("admin:djangocms_stories_post_add")
-    # first step: select app_config
-    admin_client.post(url, data={"app_config": simple_w_placeholder.pk, "language": "xx"})
-
-    # submit with invalid language code
-    data = {
-        "app_config": simple_w_placeholder.pk,
-        "content__language": "xx",
-        "content__title": "Invalid Lang Title",
-        "content__slug": "invalid-lang-slug",
-        "_save": "Save",
-    }
-    response = admin_client.post(url, data=data, follow=True)
-    assert response.status_code == 200
-
-    from djangocms_stories.models import PostContent, Post
-
-    # Content should be created either with fallback or normalized language
-    post = Post.objects.filter(postcontent__slug="invalid-lang-slug").first()
-    assert post is not None
-    pc = (
-        PostContent.admin_manager.current_content(post=post, language="en").first()
-        or PostContent.admin_manager.current_content(post=post, language="xx").first()
-    )
-    assert pc is not None
-
-
-@pytest.mark.django_db
 def test_postadmin_save_related_preserves_restricted_sites_on_remove(admin_user, default_config):
     """Edge case: user has restricted sites; removing them in form should keep them attached."""
     from djangocms_stories.admin import PostAdmin

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1085,6 +1085,111 @@ def test_postadmin_save_model_sets_default_author(admin_client, default_config):
 
 
 @pytest.mark.django_db
+def test_postadmin_save_model_missing_app_config_shows_selection(admin_client):
+    """Edge case: calling add without any app_config should show AppConfigForm."""
+    url = reverse("admin:djangocms_stories_post_add")
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    assert b"app_config" in response.content
+
+
+@pytest.mark.django_db
+def test_postadmin_save_model_invalid_language_falls_back(admin_client, simple_w_placeholder):
+    """Edge case: submitting with an unknown language should not crash and use defaults."""
+    url = reverse("admin:djangocms_stories_post_add")
+    # first step: select app_config
+    admin_client.post(url, data={"app_config": simple_w_placeholder.pk, "language": "xx"})
+
+    # submit with invalid language code
+    data = {
+        "app_config": simple_w_placeholder.pk,
+        "content__language": "xx",
+        "content__title": "Invalid Lang Title",
+        "content__slug": "invalid-lang-slug",
+        "_save": "Save",
+    }
+    response = admin_client.post(url, data=data, follow=True)
+    assert response.status_code == 200
+
+    from djangocms_stories.models import PostContent, Post
+
+    # Content should be created either with fallback or normalized language
+    post = Post.objects.filter(postcontent__slug="invalid-lang-slug").first()
+    assert post is not None
+    pc = (
+        PostContent.admin_manager.current_content(post=post, language="en").first()
+        or PostContent.admin_manager.current_content(post=post, language="xx").first()
+    )
+    assert pc is not None
+
+
+@pytest.mark.django_db
+def test_postadmin_save_related_preserves_restricted_sites_on_remove(admin_user, default_config):
+    """Edge case: user has restricted sites; removing them in form should keep them attached."""
+    from djangocms_stories.admin import PostAdmin
+    from djangocms_stories.models import Post
+    from django.test import RequestFactory
+    from django.contrib.admin.sites import site as admin_site
+    from django.contrib.sites.models import Site
+    from .factories import PostFactory, PostContentFactory
+
+    site1 = Site.objects.get_current()
+    Site.objects.create(domain="edge-site2.com", name="Edge Site 2")
+
+    post = PostFactory(app_config=default_config)
+    PostContentFactory(post=post, language="en")
+    post.sites.add(site1)
+
+    admin_instance = PostAdmin(Post, admin_site)
+    request = RequestFactory().post("/")
+    request.user = admin_user
+
+    # User is restricted to site1
+    admin_user.get_sites = lambda: Site.objects.filter(pk__in=[site1.pk])
+
+    class MockForm:
+        instance = post
+        cleaned_data = {"sites": []}  # user attempts to remove all sites
+
+        def save_m2m(self):
+            pass
+
+    form = MockForm()
+    admin_instance.save_related(request, form, [], False)
+    # site1 should remain attached due to restriction logic
+    post.refresh_from_db()
+    assert site1 in post.sites.all()
+
+
+@pytest.mark.django_db
+def test_postadmin_changeform_view_invalid_app_config_param(admin_client, simple_w_placeholder):
+    """Edge case: invalid app_config id in GET should not crash, should show selection or 200."""
+    # pass a non-existing app_config id
+    url = reverse("admin:djangocms_stories_post_add") + "?app_config=999999"
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    # Should show selection form since the app_config is invalid
+    assert b"app_config" in response.content
+
+
+@pytest.mark.django_db
+def test_postadmin_changeform_view_permission_denied_shows_403(admin_user, default_config):
+    """Edge case: user without add permission should get 403 on add view."""
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    user = User.objects.create_user(username="limited", email="limited@example.com", password="x")
+
+    client = Client()
+    client.force_login(user)
+
+    url = reverse("admin:djangocms_stories_post_add")
+    response = client.get(url)
+    # Depending on Django admin, can be 403 or redirect to login; accept either 302 or 403
+    assert response.status_code in [302, 403]
+
+
+@pytest.mark.django_db
 def test_postadmin_save_model_integration(admin_client, admin_user, default_config):
     """Test save_model integration through admin interface"""
     from django.urls import reverse
@@ -1175,3 +1280,104 @@ def test_postadmin_changeform_view_no_app_config(admin_client):
     # Should show app config selection form
     assert response.status_code == 200
     assert b"app_config" in response.content
+
+
+@pytest.mark.django_db
+def test_add_post_admin_flow_with_endpoints(admin_client, simple_w_placeholder):
+    """Test the complete flow of adding a post through admin endpoints."""
+    from djangocms_stories.models import Post, PostContent
+
+    # Step 1: GET request to add post URL - should return AppConfigForm
+    url = reverse("admin:djangocms_stories_post_add")
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    # Should contain app_config selection form
+    assert b"app_config" in response.content
+    assert b"select" in response.content.lower()
+
+    # Step 2: POST app_config selection to get the actual Post form
+    # The admin converts this POST to GET internally and shows the actual form
+    response = admin_client.post(
+        url,
+        data={
+            "app_config": simple_w_placeholder.pk,
+            "language": "en",
+        },
+        follow=False,
+    )
+
+    # Should return 200 with the actual post content form (not redirect)
+    assert response.status_code == 200
+    # Check that we got the Post content form (title indicates "Add English content")
+    assert b"Add" in response.content or b"add" in response.content
+    # Should have fields for PostContent
+    assert b"title" in response.content.lower() or b"id_title" in response.content.lower()
+
+    # Step 3: Submit the post content form to create the post
+    initial_post_count = Post.objects.count()
+    PostContent.objects.count()
+
+    # When using placeholder, the form expects different field names
+    post_data = {
+        "app_config": simple_w_placeholder.pk,
+        "content__language": "en",
+        "content__title": "Test Post via Admin",
+        "content__subtitle": "Test Subtitle",
+        "content__slug": "test-post-via-admin",
+        "_save": "Save",
+    }
+
+    response = admin_client.post(url, data=post_data, follow=True)
+
+    # Should get some response (either success or showing form again with errors)
+    assert response.status_code == 200
+
+    # Verify post was created
+    assert Post.objects.count() == initial_post_count + 1
+
+    # Verify the created post
+    new_post = Post.objects.latest("id")
+    assert new_post.app_config == simple_w_placeholder
+
+    # Verify the created post content
+    new_post_content = PostContent.admin_manager.current_content(post=new_post, language="en").first()
+    assert new_post_content is not None
+    assert new_post_content.title == "Test Post via Admin"
+    assert new_post_content.subtitle == "Test Subtitle"
+    assert new_post_content.slug == "test-post-via-admin"
+
+
+@pytest.mark.django_db
+def test_add_post_admin_with_preselected_config(admin_client, simple_w_placeholder):
+    """Test adding a post when app_config is already in URL parameters."""
+    from djangocms_stories.models import Post
+
+    # When app_config is in URL, should skip AppConfigForm and show Post form directly
+    url = reverse("admin:djangocms_stories_post_add") + f"?app_config={simple_w_placeholder.pk}"
+    response = admin_client.get(url)
+
+    assert response.status_code == 200
+    # Should show the post form, not the app_config selection
+    assert b"title" in response.content.lower()
+    # app_config should be pre-filled (hidden or readonly)
+    assert str(simple_w_placeholder.pk).encode() in response.content
+
+    # Verify we can submit the form
+    initial_count = Post.objects.count()
+
+    post_data = {
+        "app_config": simple_w_placeholder.pk,
+        "content__title": "test post",
+        "content__language": "en",
+        "content__slug": "test-post-preselected",
+        "_save": "Save",
+    }
+
+    response = admin_client.post(url, data=post_data, follow=True)
+
+    assert response.status_code == 200
+    assert Post.objects.count() == initial_count + 1
+
+    new_post = Post.objects.latest("id")
+    assert new_post.app_config == simple_w_placeholder

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -216,8 +216,18 @@ def test_get_published_post_version_not_postcontent(toolbar_request, mock_toolba
 
 
 @pytest.mark.django_db
-def test_get_published_post_version_with_postcontent(toolbar_request, mock_toolbar, post_content):
+def test_get_published_post_version_with_postcontent(toolbar_request, mock_toolbar, post_content, admin_user):
     """Test _get_published_post_version returns PostContent when matching language exists."""
+    from django.apps import apps
+
+    # If versioning is enabled, publish the post_content
+    if apps.is_installed("djangocms_versioning"):
+        from djangocms_versioning.models import Version
+
+        # Get the version and publish it
+        version = Version.objects.get(object_id=post_content.pk)
+        version.publish(admin_user)
+
     stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
     stories_toolbar.current_lang = "en"
 

--- a/tests/test_toolbars.py
+++ b/tests/test_toolbars.py
@@ -1,0 +1,605 @@
+import pytest
+from cms.toolbar.items import ButtonList
+from cms.cms_toolbars import ADMIN_MENU_IDENTIFIER
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+from unittest.mock import Mock, patch
+
+from djangocms_stories.cms_toolbars import StoriesToolbar
+from djangocms_stories.models import PostContent
+
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user():
+    """Create an admin user for testing."""
+    return User.objects.create_superuser(username="admin", email="admin@test.com", password="password")
+
+
+@pytest.fixture
+def toolbar_request(admin_user):
+    """Create a mock request with toolbar."""
+    factory = RequestFactory()
+    request = factory.get("/")
+    request.user = admin_user
+    request.current_page = None
+    request.session = {}
+    return request
+
+
+@pytest.fixture
+def mock_toolbar():
+    """Create a mock CMS toolbar."""
+    toolbar = Mock()
+    toolbar.obj = None
+    toolbar.edit_mode_active = False
+    toolbar.preview_mode_active = False
+    toolbar.RIGHT = "right"
+    toolbar.get_object = Mock(return_value=None)
+    return toolbar
+
+
+@pytest.mark.django_db
+def test_add_view_published_button_versioning_disabled(toolbar_request, mock_toolbar, post_content):
+    """Test add_view_published_button does nothing when versioning is disabled."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set the toolbar object to a PostContent instance
+    mock_toolbar.obj = post_content
+
+    # Mock is_versioning_enabled to return False
+    with patch("djangocms_stories.cms_toolbars.is_versioning_enabled", return_value=False):
+        # Call the method
+        stories_toolbar.add_view_published_button()
+
+        # Verify that no button was added (toolbar.add_item should not be called)
+        mock_toolbar.add_item.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_add_view_published_button_versioning_enabled_no_published_version(
+    toolbar_request, mock_toolbar, post_content
+):
+    """Test add_view_published_button does nothing when no published version exists."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set the toolbar object to a PostContent instance
+    mock_toolbar.obj = post_content
+
+    # Mock is_versioning_enabled to return True
+    with patch("djangocms_stories.cms_toolbars.is_versioning_enabled", return_value=True):
+        # Mock _get_published_post_version to return None
+        with patch.object(stories_toolbar, "_get_published_post_version", return_value=None):
+            # Call the method
+            stories_toolbar.add_view_published_button()
+
+            # Verify that no button was added
+            mock_toolbar.add_item.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_add_view_published_button_versioning_enabled_with_published_version_edit_mode(
+    toolbar_request, mock_toolbar, post_content
+):
+    """Test add_view_published_button adds button in edit mode when published version exists."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set the toolbar object to a PostContent instance
+    mock_toolbar.obj = post_content
+    mock_toolbar.edit_mode_active = True
+
+    # Create a mock published version with get_absolute_url method
+    published_version = Mock(spec=PostContent)
+    published_version.get_absolute_url = Mock(return_value="/published-url/")
+
+    # Mock is_versioning_enabled to return True
+    with patch("djangocms_stories.cms_toolbars.is_versioning_enabled", return_value=True):
+        # Mock _get_published_post_version to return the published version
+        with patch.object(stories_toolbar, "_get_published_post_version", return_value=published_version):
+            # Call the method
+            stories_toolbar.add_view_published_button()
+
+            # Verify that add_item was called
+            mock_toolbar.add_item.assert_called_once()
+
+            # Get the ButtonList that was added
+            call_args = mock_toolbar.add_item.call_args
+            button_list = call_args[0][0]
+
+            # Verify it's a ButtonList
+            assert isinstance(button_list, ButtonList)
+
+
+@pytest.mark.django_db
+def test_add_view_published_button_versioning_enabled_with_published_version_preview_mode(
+    toolbar_request, mock_toolbar, post_content
+):
+    """Test add_view_published_button adds button in preview mode when published version exists."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set the toolbar object to a PostContent instance
+    mock_toolbar.obj = post_content
+    mock_toolbar.preview_mode_active = True
+
+    # Create a mock published version with get_absolute_url method
+    published_version = Mock(spec=PostContent)
+    published_version.get_absolute_url = Mock(return_value="/published-url/")
+
+    # Mock is_versioning_enabled to return True
+    with patch("djangocms_stories.cms_toolbars.is_versioning_enabled", return_value=True):
+        # Mock _get_published_post_version to return the published version
+        with patch.object(stories_toolbar, "_get_published_post_version", return_value=published_version):
+            # Call the method
+            stories_toolbar.add_view_published_button()
+
+            # Verify that add_item was called
+            mock_toolbar.add_item.assert_called_once()
+
+            # Get the ButtonList that was added
+            call_args = mock_toolbar.add_item.call_args
+            button_list = call_args[0][0]
+
+            # Verify it's a ButtonList
+            assert isinstance(button_list, ButtonList)
+
+
+@pytest.mark.django_db
+def test_add_view_published_button_versioning_enabled_no_url(toolbar_request, mock_toolbar, post_content):
+    """Test add_view_published_button does nothing when published version has no URL."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set the toolbar object to a PostContent instance
+    mock_toolbar.obj = post_content
+    mock_toolbar.edit_mode_active = True
+
+    # Create a mock published version without get_absolute_url method
+    published_version = Mock(spec=[])  # No get_absolute_url
+
+    # Mock is_versioning_enabled to return True
+    with patch("djangocms_stories.cms_toolbars.is_versioning_enabled", return_value=True):
+        # Mock _get_published_post_version to return the published version
+        with patch.object(stories_toolbar, "_get_published_post_version", return_value=published_version):
+            # Call the method
+            stories_toolbar.add_view_published_button()
+
+            # Verify that no button was added (no get_absolute_url method)
+            mock_toolbar.add_item.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_add_view_published_button_not_in_edit_or_preview_mode(toolbar_request, mock_toolbar, post_content):
+    """Test add_view_published_button does nothing when not in edit or preview mode."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set the toolbar object to a PostContent instance
+    mock_toolbar.obj = post_content
+    mock_toolbar.edit_mode_active = False
+    mock_toolbar.preview_mode_active = False
+
+    # Create a mock published version with get_absolute_url method
+    published_version = Mock(spec=PostContent)
+    published_version.get_absolute_url = Mock(return_value="/published-url/")
+
+    # Mock is_versioning_enabled to return True
+    with patch("djangocms_stories.cms_toolbars.is_versioning_enabled", return_value=True):
+        # Mock _get_published_post_version to return the published version
+        with patch.object(stories_toolbar, "_get_published_post_version", return_value=published_version):
+            # Call the method
+            stories_toolbar.add_view_published_button()
+
+            # Verify that no button was added (not in edit or preview mode)
+            mock_toolbar.add_item.assert_not_called()
+
+
+# Tests for _get_published_post_version
+
+
+@pytest.mark.django_db
+def test_get_published_post_version_not_postcontent(toolbar_request, mock_toolbar):
+    """Test _get_published_post_version returns None when toolbar.obj is not PostContent."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set toolbar.obj to something other than PostContent
+    mock_toolbar.obj = "not a PostContent instance"
+
+    result = stories_toolbar._get_published_post_version()
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_get_published_post_version_with_postcontent(toolbar_request, mock_toolbar, post_content):
+    """Test _get_published_post_version returns PostContent when matching language exists."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "en"
+
+    # Set toolbar.obj to PostContent
+    mock_toolbar.obj = post_content
+
+    result = stories_toolbar._get_published_post_version()
+
+    # Should return a PostContent instance
+    assert result is not None
+    assert isinstance(result, PostContent)
+    assert result.language == "en"
+    assert result.post == post_content.post
+
+
+@pytest.mark.django_db
+def test_get_published_post_version_no_matching_language(toolbar_request, mock_toolbar, post_content):
+    """Test _get_published_post_version returns None when no matching language exists."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.current_lang = "de"  # Language that doesn't exist
+
+    # Set toolbar.obj to PostContent
+    mock_toolbar.obj = post_content
+
+    result = stories_toolbar._get_published_post_version()
+
+    # Should return None as no German translation exists
+    assert result is None
+
+
+# Tests for add_preview_button
+
+
+@pytest.mark.django_db
+def test_add_preview_button_conditions_not_met(toolbar_request, mock_toolbar):
+    """Test add_preview_button does nothing when conditions are not met."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = False
+
+    stories_toolbar.add_preview_button()
+
+    # Verify no button was added
+    mock_toolbar.add_item.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_add_preview_button_in_preview_mode(toolbar_request, mock_toolbar):
+    """Test add_preview_button adds 'View on site' button in preview mode."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = True
+    mock_toolbar.get_object.return_value = None
+    mock_toolbar.preview_mode_active = True
+    mock_toolbar.request_language = "en"
+
+    # Mock current_page
+    mock_page = Mock()
+    mock_page_content = Mock()
+    mock_page_content.get_absolute_url = Mock(return_value="/page-url/")
+
+    mock_pagecontent_set = Mock()
+    mock_pagecontent_set.latest_content = Mock(return_value=Mock(first=Mock(return_value=mock_page_content)))
+    mock_page.pagecontent_set = Mock(return_value=mock_pagecontent_set)
+
+    toolbar_request.current_page = mock_page
+
+    with patch("djangocms_stories.cms_toolbars.get_object_preview_url", return_value="/preview-url/"):
+        stories_toolbar.add_preview_button()
+
+    # Verify button was added
+    mock_toolbar.add_item.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_add_preview_button_in_edit_mode(toolbar_request, mock_toolbar):
+    """Test add_preview_button adds 'Preview' button in edit mode."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = True
+    mock_toolbar.get_object.return_value = None
+    mock_toolbar.preview_mode_active = False
+    mock_toolbar.request_language = "en"
+
+    # Mock current_page
+    mock_page = Mock()
+    mock_page_content = Mock()
+    mock_page_content.get_absolute_url = Mock(return_value="/page-url/")
+
+    mock_pagecontent_set = Mock()
+    mock_pagecontent_set.latest_content = Mock(return_value=Mock(first=Mock(return_value=mock_page_content)))
+    mock_page.pagecontent_set = Mock(return_value=mock_pagecontent_set)
+
+    toolbar_request.current_page = mock_page
+
+    with patch("djangocms_stories.cms_toolbars.get_object_preview_url", return_value="/preview-url/"):
+        stories_toolbar.add_preview_button()
+
+    # Verify button was added
+    mock_toolbar.add_item.assert_called_once()
+
+
+# Tests for add_stories_to_admin_menu
+
+
+@pytest.mark.django_db
+def test_add_stories_to_admin_menu(toolbar_request, mock_toolbar):
+    """Test add_stories_to_admin_menu adds menu item to admin menu."""
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+
+    # Mock admin menu
+    mock_admin_menu = Mock()
+    mock_toolbar.get_or_create_menu = Mock(return_value=mock_admin_menu)
+
+    with patch.object(stories_toolbar, "get_insert_position_for_admin_object", return_value=5):
+        stories_toolbar.add_stories_to_admin_menu()
+
+    # Verify get_or_create_menu was called with correct identifier
+    mock_toolbar.get_or_create_menu.assert_called_once_with(ADMIN_MENU_IDENTIFIER)
+
+    # Verify add_sideframe_item was called
+    mock_admin_menu.add_sideframe_item.assert_called_once()
+
+    # Verify position was used
+    call_args = mock_admin_menu.add_sideframe_item.call_args
+    assert call_args[1]["position"] == 5
+
+
+# Tests for get_insert_position_for_admin_object
+
+
+def test_get_insert_position_early_break():
+    """Test get_insert_position_for_admin_object when break index < 2."""
+    mock_menu = Mock()
+    mock_break = Mock()
+    mock_break.index = 1
+    mock_menu.find_first = Mock(return_value=mock_break)
+
+    position = StoriesToolbar.get_insert_position_for_admin_object(mock_menu, "Test Item")
+
+    assert position == 1
+
+
+def test_get_insert_position_alphabetical_first():
+    """Test get_insert_position_for_admin_object inserts alphabetically first."""
+    mock_menu = Mock()
+    mock_break = Mock()
+    mock_break.index = 5
+
+    # Create mock items with names
+    mock_item1 = Mock()
+    mock_item1.name = "Pages"
+    mock_item2 = Mock()
+    mock_item2.name = "Users"
+    mock_item3 = Mock()
+    mock_item3.name = "Widgets"
+
+    mock_menu.find_first = Mock(return_value=mock_break)
+    mock_menu.get_items = Mock(return_value=[None, mock_item1, mock_item2, mock_item3, None])
+
+    # "Articles" should come before "Pages"
+    position = StoriesToolbar.get_insert_position_for_admin_object(mock_menu, "Articles")
+
+    assert position == 1
+
+
+def test_get_insert_position_alphabetical_middle():
+    """Test get_insert_position_for_admin_object inserts alphabetically in middle."""
+    mock_menu = Mock()
+    mock_break = Mock()
+    mock_break.index = 5
+
+    # Create mock items with names
+    mock_item1 = Mock()
+    mock_item1.name = "Articles"
+    mock_item2 = Mock()
+    mock_item2.name = "Pages"
+    mock_item3 = Mock()
+    mock_item3.name = "Widgets"
+
+    mock_menu.find_first = Mock(return_value=mock_break)
+    mock_menu.get_items = Mock(return_value=[None, mock_item1, mock_item2, mock_item3, None])
+
+    # "Users" should come between "Pages" and "Widgets"
+    position = StoriesToolbar.get_insert_position_for_admin_object(mock_menu, "Users")
+
+    assert position == 3
+
+
+def test_get_insert_position_alphabetical_last():
+    """Test get_insert_position_for_admin_object inserts at end when alphabetically last."""
+    mock_menu = Mock()
+    mock_break = Mock()
+    mock_break.index = 5
+
+    # Create mock items with names
+    mock_item1 = Mock()
+    mock_item1.name = "Articles"
+    mock_item2 = Mock()
+    mock_item2.name = "Pages"
+    mock_item3 = Mock()
+    mock_item3.name = "Users"
+
+    mock_menu.find_first = Mock(return_value=mock_break)
+    mock_menu.get_items = Mock(return_value=[None, mock_item1, mock_item2, mock_item3, None])
+
+    # "Zebra" should come after all items
+    position = StoriesToolbar.get_insert_position_for_admin_object(mock_menu, "Zebra")
+
+    assert position == 5
+
+
+def test_get_insert_position_item_without_name():
+    """Test get_insert_position_for_admin_object handles items without name attribute."""
+    mock_menu = Mock()
+    mock_break = Mock()
+    mock_break.index = 5
+
+    # Create mock items, some without names
+    mock_item1 = Mock()
+    mock_item1.name = "Articles"
+    mock_item2 = Mock(spec=[])  # No name attribute
+    mock_item3 = Mock()
+    mock_item3.name = "Widgets"
+
+    mock_menu.find_first = Mock(return_value=mock_break)
+    mock_menu.get_items = Mock(return_value=[None, mock_item1, mock_item2, mock_item3, None])
+
+    # Should handle items without name gracefully
+    position = StoriesToolbar.get_insert_position_for_admin_object(mock_menu, "Users")
+
+    # Should still work and find correct position
+    assert isinstance(position, int)
+
+
+# Tests for populate method
+
+
+@pytest.mark.django_db
+def test_populate_without_permission(toolbar_request, mock_toolbar, simple_w_placeholder):
+    """Test populate returns early when user has no add_post permission."""
+    # Create user without permission
+    user = User.objects.create_user(username="nonadmin", email="user@test.com", password="password")
+    toolbar_request.user = user
+
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = True
+
+    with patch.object(stories_toolbar, "add_stories_to_admin_menu"):
+        with patch.object(stories_toolbar, "add_preview_button"):
+            with patch.object(stories_toolbar, "add_view_published_button"):
+                stories_toolbar.populate()
+
+    # Verify menus were not created (except admin menu)
+    calls = mock_toolbar.get_or_create_menu.call_args_list
+    # Should only have admin menu, not djangocms_stories menu
+    for call in calls:
+        assert call[0][0] != "djangocms_stories"
+
+
+@pytest.mark.django_db
+def test_populate_with_postcontent(toolbar_request, mock_toolbar, post_content, admin_user):
+    """Test populate creates menu with PostContent as current content."""
+    toolbar_request.user = admin_user
+    mock_toolbar.get_object.return_value = post_content
+
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = True
+    stories_toolbar.current_lang = "en"
+
+    # Mock the djangocms_stories menu
+    mock_stories_menu = Mock()
+
+    def get_or_create_menu_side_effect(identifier, *args, **kwargs):
+        if identifier == ADMIN_MENU_IDENTIFIER:
+            return Mock()
+        elif identifier == "djangocms_stories":
+            return mock_stories_menu
+        return Mock()
+
+    mock_toolbar.get_or_create_menu = Mock(side_effect=get_or_create_menu_side_effect)
+
+    with patch.object(stories_toolbar, "add_stories_to_admin_menu"):
+        with patch.object(stories_toolbar, "add_preview_button"):
+            with patch.object(stories_toolbar, "add_view_published_button"):
+                with patch("djangocms_stories.cms_toolbars.get_setting") as mock_get_setting:
+                    mock_get_setting.side_effect = lambda x: {
+                        "ENABLE_THROUGH_TOOLBAR_MENU": True,
+                        "CURRENT_POST_IDENTIFIER": "djangocms_stories_current_post",
+                        "CURRENT_NAMESPACE": "djangocms_stories_current_app_config",
+                    }.get(x, x)
+
+                    stories_toolbar.populate()
+
+    # Verify stories menu was created
+    assert any(call[0][0] == "djangocms_stories" for call in mock_toolbar.get_or_create_menu.call_args_list)
+
+    # Verify modal item was added (properties)
+    mock_stories_menu.add_modal_item.assert_called()
+
+
+@pytest.mark.django_db
+def test_populate_with_app_config(toolbar_request, mock_toolbar, post_content, admin_user):
+    """Test populate creates full menu with app_config."""
+    from djangocms_stories.models import StoriesConfig
+    from djangocms_stories.cms_appconfig import config_defaults
+
+    # Create a unique config for this test
+    app_config = StoriesConfig.objects.create(
+        **{
+            **config_defaults,
+            "namespace": "test_toolbar_populate",
+            "app_title": "Test Toolbar Config",
+            "object_name": "Story",
+            "url_patterns": "full_date",
+        }
+    )
+
+    toolbar_request.user = admin_user
+    toolbar_request.djangocms_stories_current_post = post_content
+    toolbar_request.djangocms_stories_current_app_config = app_config
+    mock_toolbar.get_object.return_value = post_content
+
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = True
+    stories_toolbar.current_lang = "en"
+
+    # Mock the djangocms_stories menu
+    mock_stories_menu = Mock()
+
+    def get_or_create_menu_side_effect(identifier, *args, **kwargs):
+        if identifier == ADMIN_MENU_IDENTIFIER:
+            return Mock()
+        elif identifier == "djangocms_stories":
+            return mock_stories_menu
+        return Mock()
+
+    mock_toolbar.get_or_create_menu = Mock(side_effect=get_or_create_menu_side_effect)
+
+    with patch.object(stories_toolbar, "add_stories_to_admin_menu"):
+        with patch.object(stories_toolbar, "add_preview_button"):
+            with patch.object(stories_toolbar, "add_view_published_button"):
+                with patch("djangocms_stories.cms_toolbars.get_setting") as mock_get_setting:
+                    mock_get_setting.side_effect = lambda x: {
+                        "ENABLE_THROUGH_TOOLBAR_MENU": True,
+                        "CURRENT_POST_IDENTIFIER": "djangocms_stories_current_post",
+                        "CURRENT_NAMESPACE": "djangocms_stories_current_app_config",
+                    }.get(x, x)
+
+                    stories_toolbar.populate()
+
+    # Verify modal items were added
+    assert mock_stories_menu.add_modal_item.call_count >= 2  # Properties, New entry, Edit config
+
+    # Verify sideframe item was added (All entries)
+    mock_stories_menu.add_sideframe_item.assert_called()
+
+    # Verify break was added
+    mock_stories_menu.add_break.assert_called()
+
+
+@pytest.mark.django_db
+def test_populate_calls_helper_methods(toolbar_request, mock_toolbar, admin_user):
+    """Test populate calls all helper methods."""
+    toolbar_request.user = admin_user
+
+    stories_toolbar = StoriesToolbar(toolbar_request, mock_toolbar, False, None)
+    stories_toolbar.is_current_app = False
+
+    # Mock the admin menu
+    mock_toolbar.get_or_create_menu = Mock(return_value=Mock())
+
+    with patch.object(stories_toolbar, "add_stories_to_admin_menu") as mock_add_admin:
+        with patch.object(stories_toolbar, "add_preview_button"):
+            with patch.object(stories_toolbar, "add_view_published_button"):
+                with patch("djangocms_stories.cms_toolbars.get_setting") as mock_get_setting:
+                    mock_get_setting.side_effect = lambda x: {
+                        "ENABLE_THROUGH_TOOLBAR_MENU": False,
+                        "CURRENT_POST_IDENTIFIER": "djangocms_stories_current_post",
+                        "CURRENT_NAMESPACE": "djangocms_stories_current_app_config",
+                    }.get(x, x)
+
+                    stories_toolbar.populate()
+
+    # Verify all helper methods were called
+    mock_add_admin.assert_called_once()
+    # add_preview_button and add_view_published_button should be called even if menu is not created
+    # because they are at the end of populate()


### PR DESCRIPTION
## Summary by Sourcery

Harden the two-step admin flow for adding blog posts and expand test coverage, including CMS toolbar behaviour and edge cases in the admin UI.

Bug Fixes:
- Handle invalid or missing app_config IDs in the stories admin add view without errors, correctly falling back to the app-config selection step.
- Normalize or fall back from invalid content language codes in the admin add form to avoid crashes and ensure posts are still created.
- Ensure restricted site relations on posts are preserved when a restricted user submits the admin form removing all sites.
- Avoid misbehaviour when initializing forms with instance or app_config data by tightening initial value handling.

Tests:
- Add comprehensive tests covering the full two-step admin flow for adding posts, including pre-selected app_config and invalid language inputs.
- Add regression tests for admin edge cases such as invalid app_config query params, missing app_config, user permission handling, and site restriction behaviour.
- Introduce an extensive test suite for the StoriesToolbar, covering preview/view-published buttons, admin menu integration, menu insertion ordering, and toolbar population logic.