### PR TITLE
fix: Redirect used wrong url pattern

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,12 @@
+[main]
+host = https://app.transifex.com
+
+[o:divio:p:django-cms-stories:r:djangopo]
+file_filter            = djangocms_stories/locale/<lang>/LC_MESSAGES/django.po
+source_file            = djangocms_stories/locale/en/LC_MESSAGES/django.po
+type                   = PO
+minimum_perc           = 0
+resource_name          = django.po
+replace_edited_strings = false
+keep_translations      = false
+

--- a/djangocms_stories/admin.py
+++ b/djangocms_stories/admin.py
@@ -4,7 +4,7 @@ from cms.admin.placeholderadmin import FrontendEditableAdminMixin
 from cms.admin.utils import GrouperModelAdmin
 from cms.models import ValidationError
 from cms.utils import get_language_from_request
-from cms.utils.urlutils import admin_reverse
+from cms.utils.urlutils import admin_namespace, admin_reverse
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin import helpers
@@ -507,7 +507,7 @@ class PostAdmin(
         urls = [
             path(
                 "content/",
-                RedirectView.as_view(pattern_name="admin:djangocms_stories_post_changelist"),
+                RedirectView.as_view(pattern_name=f"{admin_namespace}:djangocms_stories_post_changelist"),
                 name="djangocms_stories_postcontent_changelist",
             ),
         ]

--- a/djangocms_stories/admin.py
+++ b/djangocms_stories/admin.py
@@ -4,7 +4,8 @@ from cms.admin.placeholderadmin import FrontendEditableAdminMixin
 from cms.admin.utils import GrouperModelAdmin
 from cms.models import ValidationError
 from cms.utils import get_language_from_request
-from cms.utils.urlutils import admin_namespace, admin_reverse
+from cms.utils.conf import get_cms_setting
+from cms.utils.urlutils import admin_reverse
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin import helpers
@@ -27,6 +28,7 @@ from .settings import get_setting
 from .utils import is_versioning_enabled
 
 signal_dict = {}
+admin_namespace = get_cms_setting("ADMIN_NAMESPACE")
 
 
 def register_extension(klass):

--- a/djangocms_stories/admin.py
+++ b/djangocms_stories/admin.py
@@ -507,7 +507,7 @@ class PostAdmin(
         urls = [
             path(
                 "content/",
-                RedirectView.as_view(pattern_name="djangocms_stories_post_changelist"),
+                RedirectView.as_view(pattern_name="admin:djangocms_stories_post_changelist"),
                 name="djangocms_stories_postcontent_changelist",
             ),
         ]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1073,6 +1073,19 @@ def test_postadmin_get_urls_custom():
     assert "djangocms_stories_postcontent_changelist" in url_patterns
 
 
+def test_postadmin_postcontent_changelist_redirects(admin_client):
+    """The custom admin URL 'content/' should redirect to the Post changelist."""
+
+    # The custom URL is registered on the Post admin (".../post/content/").
+    # We build it from the Post changelist URL to avoid a name collision with
+    # the PostContent modeladmin changelist.
+    url = reverse("admin:djangocms_stories_post_changelist").rstrip("/") + "/content/"
+    response = admin_client.get(url)
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse("admin:djangocms_stories_post_changelist")
+
+
 def test_postadmin_save_related_no_restricted_sites(admin_user, default_config):
     """Test save_related when user has no restricted sites"""
     from djangocms_stories.admin import PostAdmin


### PR DESCRIPTION
Fixes #76

## Summary by Sourcery

Correct the admin content redirect to use the properly namespaced changelist URL and add translation configuration.

Bug Fixes:
- Fix the admin content redirect to point to the correctly namespaced post changelist URL.

Chores:
- Add Transifex configuration file for managing translations.