### PR TITLE
FIX: fix setting to disable unicode chars in slug fields

### DIFF
--- a/djangocms_stories/fields.py
+++ b/djangocms_stories/fields.py
@@ -1,11 +1,13 @@
 from django import forms
 from django.utils.text import slugify as django_slugify
 
+from .settings import get_setting
+
 __all__ = ["slugify", "LanguageSelector"]
 
 
 def slugify(base):
-    return django_slugify(base, allow_unicode=True)
+    return django_slugify(base, allow_unicode=get_setting("ALLOW_UNICODE_SLUGS"))
 
 
 class LanguageSelector(forms.Select):


### PR DESCRIPTION
Add 2-lines fix used in [this PR](https://github.com/kapt-labs/djangocms-blog/commit/876a027157931d71ffb43f330a609d70e58c00b7) on djangocms-blog to enable/disable unicode in slugs using `STORIES_ALLOW_UNICODE_SLUGS` setting.