### PR TITLE
fix: set post published dates

### DIFF
--- a/djangocms_stories/apps.py
+++ b/djangocms_stories/apps.py
@@ -1,4 +1,4 @@
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 from django.core.checks import Warning, register
 from django.utils.translation import gettext_lazy as _
 
@@ -10,18 +10,17 @@ class BlogAppConfig(AppConfig):
 
     def ready(self):
         register(check_settings)
-        try:
+        # Set date_published and date_published_end when a post is published/unpublished
+        if apps.is_installed("djangocms_versioning"):
             from djangocms_versioning.signals import post_version_operation
             from .signal_handlers import handle_version_operation
-            # Set date_published and date_published_end when a post is published/unpublished
             post_version_operation.connect(
                 handle_version_operation,
-                dispatch_uid="stories_handle_version_operation",
+                dispatch_uid="stories_handle_version_operation"
             )
-        except ImportError:
-            pass
-        return super().ready()
 
+        return super().ready()
+        
 
 def check_settings(*args, **kwargs):  # pragma: no cover
     from django.conf import settings

--- a/djangocms_stories/apps.py
+++ b/djangocms_stories/apps.py
@@ -13,11 +13,12 @@ class BlogAppConfig(AppConfig):
         # Set date_published and date_published_end when a post is published/unpublished
         if apps.is_installed("djangocms_versioning"):
             from djangocms_versioning.signals import post_version_operation
-            from .signal_handlers import handle_version_operation
+            from .signal_handlers import set_published_dates
             post_version_operation.connect(
-                handle_version_operation,
-                dispatch_uid="stories_handle_version_operation"
+                set_published_dates,
+                dispatch_uid="stories_set_published_dates"
             )
+
         return super().ready()
         
 

--- a/djangocms_stories/apps.py
+++ b/djangocms_stories/apps.py
@@ -18,7 +18,6 @@ class BlogAppConfig(AppConfig):
                 handle_version_operation,
                 dispatch_uid="stories_handle_version_operation"
             )
-
         return super().ready()
         
 

--- a/djangocms_stories/apps.py
+++ b/djangocms_stories/apps.py
@@ -13,7 +13,7 @@ class BlogAppConfig(AppConfig):
         # Set date_published and date_published_end when a post is published/unpublished
         if apps.is_installed("djangocms_versioning"):
             from djangocms_versioning.signals import post_version_operation
-            from .signal_handlers import set_published_dates
+            from .versioning_signals import set_published_dates
             post_version_operation.connect(
                 set_published_dates,
                 dispatch_uid="stories_set_published_dates"

--- a/djangocms_stories/apps.py
+++ b/djangocms_stories/apps.py
@@ -14,7 +14,10 @@ class BlogAppConfig(AppConfig):
             from djangocms_versioning.signals import post_version_operation
             from .signal_handlers import handle_version_operation
             # Set date_published and date_published_end when a post is published/unpublished
-            post_version_operation.connect(handle_version_operation)
+            post_version_operation.connect(
+                handle_version_operation,
+                dispatch_uid="stories_handle_version_operation",
+            )
         except ImportError:
             pass
         return super().ready()

--- a/djangocms_stories/apps.py
+++ b/djangocms_stories/apps.py
@@ -10,6 +10,13 @@ class BlogAppConfig(AppConfig):
 
     def ready(self):
         register(check_settings)
+        try:
+            from djangocms_versioning.signals import post_version_operation
+            from .signal_handlers import handle_version_operation
+            # Set date_published and date_published_end when a post is published/unpublished
+            post_version_operation.connect(handle_version_operation)
+        except ImportError:
+            pass
         return super().ready()
 
 

--- a/djangocms_stories/signal_handlers.py
+++ b/djangocms_stories/signal_handlers.py
@@ -1,0 +1,21 @@
+from django.utils.timezone import now
+from djangocms_versioning.constants import OPERATION_PUBLISH, OPERATION_UNPUBLISH
+from .models import PostContent
+
+
+def handle_version_operation(sender, obj, operation, **kwargs):
+    """
+    When a post is published for the first time, record the date. When it's unpublished, record that date too.
+    """
+    if not hasattr(obj, 'content') or not isinstance(obj.content, PostContent):
+        return  
+
+    post = obj.content.post
+
+    if operation == OPERATION_PUBLISH and not post.date_published:
+        post.date_published = now()
+        post.save(update_fields=["date_published"])
+
+    elif operation == OPERATION_UNPUBLISH:
+        post.date_published_end = now()
+        post.save(update_fields=["date_published_end"])

--- a/djangocms_stories/signal_handlers.py
+++ b/djangocms_stories/signal_handlers.py
@@ -1,21 +1,27 @@
 from django.utils.timezone import now
 from djangocms_versioning.constants import OPERATION_PUBLISH, OPERATION_UNPUBLISH
+from djangocms_versioning.models import Version
 from .models import PostContent
 
 
-def handle_version_operation(sender, obj, operation, **kwargs):
+def set_published_dates(sender, obj, operation, **kwargs):
     """
-    When a post is published for the first time, record the date. When it's unpublished, record that date too.
+    When a post is published for the first time, or unplished record the date. 
+    And when republished clear the date_published_end.
     """
-    if not hasattr(obj, 'content') or not isinstance(obj.content, PostContent):
-        return  
+    if not isinstance(obj, Version) or not isinstance(obj.content, PostContent):
+        return
 
     post = obj.content.post
 
-    if operation == OPERATION_PUBLISH and not post.date_published:
-        post.date_published = now()
-        post.save(update_fields=["date_published"])
+    if operation == OPERATION_PUBLISH:
+        if not post.date_published:
+            post.date_published = now()
+        if post.date_published_end and post.date_published_end < now():
+            post.date_published_end = None
+        post.save(update_fields=["date_published", "date_published_end"])
 
     elif operation == OPERATION_UNPUBLISH:
-        post.date_published_end = now()
-        post.save(update_fields=["date_published_end"])
+        if not post.date_published_end or post.date_published_end < now():
+            post.date_published_end = now()
+            post.save(update_fields=["date_published_end"])

--- a/djangocms_stories/signal_handlers.py
+++ b/djangocms_stories/signal_handlers.py
@@ -1,7 +1,8 @@
 from django.utils.timezone import now
-from djangocms_versioning.constants import OPERATION_PUBLISH, OPERATION_UNPUBLISH
+from djangocms_versioning.constants import OPERATION_PUBLISH, OPERATION_UNPUBLISH, PUBLISHED
 from djangocms_versioning.models import Version
 from .models import PostContent
+from django.contrib.contenttypes.models import ContentType
 
 
 def set_published_dates(sender, obj, operation, **kwargs):
@@ -22,6 +23,17 @@ def set_published_dates(sender, obj, operation, **kwargs):
         post.save(update_fields=["date_published", "date_published_end"])
 
     elif operation == OPERATION_UNPUBLISH:
-        if not post.date_published_end or post.date_published_end < now():
-            post.date_published_end = now()
-            post.save(update_fields=["date_published_end"])
+        content_type = ContentType.objects.get_for_model(PostContent)
+        no_published_languages = (
+            Version.objects.filter(
+                content_type=content_type,
+                object_id__in=post.postcontent_set.values_list("id", flat=True),
+                state=PUBLISHED,
+            )
+            .exclude(pk=obj.pk) .exists()
+        )
+
+        if not no_published_languages:
+            if not post.date_published_end or post.date_published_end < now():
+                post.date_published_end = now()
+                post.save(update_fields=["date_published_end"])

--- a/djangocms_stories/versioning_signals.py
+++ b/djangocms_stories/versioning_signals.py
@@ -1,3 +1,10 @@
+# This file is only imported ever if djangocsm-versioning is installed into
+# a project. It takes its signals to set publication dates.
+#
+# Using a different versioning mechanism, you will have to either set the#
+# dates manually or provide custom logic.
+
+
 from django.utils.timezone import now
 from djangocms_versioning.constants import OPERATION_PUBLISH, OPERATION_UNPUBLISH, PUBLISHED
 from djangocms_versioning.models import Version

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -1,0 +1,126 @@
+import pytest
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.utils.timezone import now, timedelta
+
+
+pytestmark = pytest.mark.skipif(
+    not apps.is_installed("djangocms_versioning"),
+    reason="djangocms-versioning is not installed",
+)
+
+
+def get_version(post_content):
+    """Return the Version object for a given PostContent instance."""
+    from djangocms_versioning.models import Version
+
+    ct = ContentType.objects.get_for_model(post_content)
+    return Version.objects.get(content_type=ct, object_id=post_content.pk)
+
+
+
+@pytest.mark.django_db
+def test_publish_sets_date_published(default_config, admin_user):
+    """First publish sets date_published on the Post."""
+    from tests.factories import PostContentFactory
+
+    post_content = PostContentFactory(
+        post__app_config=default_config, post__date_published=None
+    )
+    post = post_content.post
+    assert post.date_published is None
+
+    get_version(post_content).publish(user=admin_user)
+
+    post.refresh_from_db()
+    assert post.date_published is not None
+
+
+@pytest.mark.django_db
+def test_publish_does_not_overwrite_existing_date_published(default_config, admin_user):
+    """Republishing a new version keeps the original date_published."""
+    from tests.factories import PostContentFactory
+
+    post_content = PostContentFactory(
+        post__app_config=default_config, post__date_published=None
+    )
+    post = post_content.post
+
+    version = get_version(post_content)
+    version.publish(user=admin_user)
+    post.refresh_from_db()
+    original_date = post.date_published
+    assert original_date is not None
+
+    version.unpublish(user=admin_user)
+
+    new_version = get_version(PostContentFactory(post=post))
+    new_version.publish(user=admin_user)
+
+    post.refresh_from_db()
+    assert post.date_published == original_date
+
+
+
+
+@pytest.mark.django_db
+def test_unpublish_sets_date_published_end(default_config, admin_user):
+    """Unpublishing records date_published_end on the Post."""
+    from tests.factories import PostContentFactory
+
+    post_content = PostContentFactory(
+        post__app_config=default_config, post__date_published_end=None
+    )
+    post = post_content.post
+
+    version = get_version(post_content)
+    version.publish(user=admin_user)
+    version.unpublish(user=admin_user)
+
+    post.refresh_from_db()
+    assert post.date_published_end is not None
+
+
+
+@pytest.mark.django_db
+def test_republish_clears_date_published_end(default_config, admin_user):
+    """ republished clears date_published_end (Published since)"""
+    from tests.factories import PostContentFactory
+
+    post_content = PostContentFactory(
+        post__app_config=default_config, post__date_published_end=None
+    )
+    post = post_content.post
+
+    version = get_version(post_content)
+    version.publish(user=admin_user)
+    version.unpublish(user=admin_user)
+
+    post.refresh_from_db()
+    assert post.date_published_end is not None  
+
+    new_version = get_version(PostContentFactory(post=post))
+    new_version.publish(user=admin_user)
+
+    post.refresh_from_db()
+    assert post.date_published_end is None
+
+
+@pytest.mark.django_db
+def test_republish_keeps_future_date_published_end(default_config, admin_user):
+    """
+    If it is set to a future date republishing a new version must not clear it.
+    """
+    from tests.factories import PostContentFactory
+
+    future = now() + timedelta(days=30)
+    post_content = PostContentFactory(
+        post__app_config=default_config, post__date_published_end=future
+    )
+    post = post_content.post
+
+    version = get_version(post_content)
+    version.publish(user=admin_user)
+
+    post.refresh_from_db()
+    assert post.date_published_end == future  


### PR DESCRIPTION
When a post is published or unpublished through djangocms-versioning, the date_published and date_published_end fields on the Post model are never set. This PR fixes that by listening to the post_version_operation signal.

Changes:

- Added signal_handlers.py with a handler that stamps date_published (Published Since) on first publish and date_published_end (Published Until) on unpublish
- Linked the signal in BlogAppConfig.ready() with a try/except


fixes #83 

## Summary by Sourcery

Update blog app to set post publish timestamps based on djangocms-versioning operations.

Bug Fixes:
- Ensure post date_published is set on first publish via djangocms-versioning.
- Ensure post date_published_end is set when a post is unpublished via djangocms-versioning.

Enhancements:
- Connect a version operation signal handler in BlogAppConfig, guarded when djangocms-versioning is not installed.