### PR TITLE
fix: exclude current post from related selection

### DIFF
--- a/djangocms_stories/admin.py
+++ b/djangocms_stories/admin.py
@@ -621,7 +621,9 @@ class PostAdmin(
         if sites:
             pks = [site.pk for site in sites]
             qs = qs.filter(sites__in=pks)
-        prefetch = models.Prefetch("postcontent_set", queryset=PostContent.admin_manager.latest_content(), to_attr="_admin_prefetch_cache")
+        prefetch = models.Prefetch(
+            "postcontent_set", queryset=PostContent.admin_manager.latest_content(), to_attr="_admin_prefetch_cache"
+        )
         return qs.select_related("author", "app_config").prefetch_related(prefetch, "categories", "sites")
 
     def get_content_obj(self, obj):
@@ -631,7 +633,9 @@ class PostAdmin(
             return self._content_obj_cache[obj]
         if hasattr(obj, "_admin_prefetch_cache"):
             for content_obj in obj._admin_prefetch_cache:
-                if all(getattr(content_obj, key, None) == value for key, value in self.current_content_filters.items()):
+                if all(
+                    getattr(content_obj, key, None) == value for key, value in self.current_content_filters.items()
+                ):
                     self._content_obj_cache[obj] = content_obj
                     return content_obj
             self._content_obj_cache[obj] = None
@@ -652,8 +656,15 @@ class PostAdmin(
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         if db_field.name == "related":
             qs = self.get_queryset(request)
+
+            resolved = request.resolver_match
+            if resolved and "object_id" in resolved.kwargs:
+                qs = qs.exclude(pk=resolved.kwargs["object_id"])
+
             kwargs["queryset"] = qs
+
         return super().formfield_for_manytomany(db_field, request, **kwargs)
+
 
 @admin.register(PostContent)
 class PostContentAdmin(FrontendEditableAdminMixin, admin.ModelAdmin):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -240,8 +240,10 @@ def test_post_change_admin(admin_client, default_config, assert_html_in_response
     )
 
     # Both post and post content fields are present
-    if DJANGO_VERSION >= (6,0):
-        assert_html_in_response('<legend class="inline" for="id_author">Author:</legend>', response)  # Post author field
+    if DJANGO_VERSION >= (6, 0):
+        assert_html_in_response(
+            '<legend class="inline" for="id_author">Author:</legend>', response
+        )  # Post author field
     else:
         assert_html_in_response('<label class="inline" for="id_author">Author:</label>', response)  # Post author field
     assert_html_in_response(
@@ -299,7 +301,7 @@ def test_postadmin_lookup_allowed(admin_user):
     else:
         assert admin_instance.lookup_allowed("post__categories__name", None)
         assert admin_instance.lookup_allowed("post__app_config__namespace", None)
-    
+
 
 def test_postadmin_has_restricted_sites_no_restriction(admin_user):
     """Test has_restricted_sites when user has no site restrictions"""
@@ -438,6 +440,23 @@ def test_postadmin_fieldsets_with_related(admin_user, default_config):
             flat_fields.append(field)
 
     assert "related" in flat_fields
+
+
+def test_related_posts_queryset_excludes_self(admin_client, default_config):
+    """
+    Test that ensures that a post is excluded from its own 'related posts' section
+    in the admin view.
+    """
+    from .factories import PostFactory
+
+    post = PostFactory(app_config=default_config)
+    url = reverse("admin:djangocms_stories_post_change", args=[post.pk])
+    response = admin_client.get(url)
+
+    form = response.context["adminform"].form
+    related_queryset = form.fields["related"].queryset
+
+    assert post not in related_queryset
 
 
 def test_config_admin_readonly_namespace(admin_user, default_config):


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

This PR fixes an issue where a `Post` could be marked as related to itself. To solve this issue I decided to exclude the current post from the selection list entirely. I also added a test to ensure that the issue has been fixed.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #86 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on

## Summary by Sourcery

Prevent posts from being selectable as related to themselves in the admin interface.

Bug Fixes:
- Exclude the current post from the queryset used for selecting related posts in the admin form.

Tests:
- Add an admin view test verifying that a post is not present in its own related posts queryset.