### PR TITLE
docs: add missing djangocms-text dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ To install the latest version directly from GitHub, run:
 
     pip install djangocms-stories djangocms-text
 
-Add ``djangocms_stories`` to your ``INSTALLED_APPS`` in your Django project's ``settings.py``:
+Add ``djangocms_stories`` and ``djangocms_text`` to your ``INSTALLED_APPS`` in your Django project's ``settings.py``:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ To install the latest version directly from GitHub, run:
 
 .. code-block:: bash
 
-    pip install djangocms-stories
+    pip install djangocms-stories djangocms-text
 
 Add ``djangocms_stories`` to your ``INSTALLED_APPS`` in your Django project's ``settings.py``:
 
@@ -41,6 +41,7 @@ Add ``djangocms_stories`` to your ``INSTALLED_APPS`` in your Django project's ``
 
     INSTALLED_APPS = [
         # ...
+        'djangocms_text',  # required
         'djangocms_stories',
         'parler',  # if not already included
         'sortedm2m',  # if not already included

--- a/docs/how-tos/migration-from-blog.rst
+++ b/docs/how-tos/migration-from-blog.rst
@@ -27,15 +27,16 @@ Step 1: Install djangocms-stories alongside djangocms-blog
 Uninstall the old package and install the new one::
 
     pip uninstall djangocms-blog
-    pip install djangocms-stories
+    pip install djangocms-stories djangocms-text
 
-Then add ``djangocms_stories`` to ``INSTALLED_APPS`` while keeping ``djangocms_blog`` temporarily:
+Then add ``djangocms_stories`` and the required ``djangocms_text`` to ``INSTALLED_APPS`` while keeping ``djangocms_blog`` temporarily:
 
 .. code-block:: python
 
     INSTALLED_APPS = [
         # ...
         'djangocms_blog',      # keep for now — the migration reads its tables
+        'djangocms_text',      # required
         'djangocms_stories',   # new
         # ...
     ]
@@ -46,6 +47,7 @@ Step 2: Run the data migration
 Run migrations for both apps::
 
     python manage.py migrate djangocms_blog
+    python manage.py migrate djangocms_text
     python manage.py migrate djangocms_stories
 
 The djangocms-stories migration ``0002`` reads all existing blog data — posts, categories,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ Installation steps
 
   .. code-block:: bash
 
-      pip install djangocms-stories
+      pip install djangocms-stories djangocms-text
 
 * Add ``djangocms_stories`` and its dependencies to INSTALLED_APPS:
 
@@ -37,6 +37,7 @@ Installation steps
             'taggit_autosuggest',
             'meta',
             'sortedm2m',
+            'djangocms_text',
             'djangocms_stories',
             ...
         ]

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -12,7 +12,7 @@ Installing djangocms-stories
 
 Install using pip::
 
-    pip install djangocms-stories
+    pip install djangocms-stories djangocms-text
 
 Add to your Django settings
 ============================
@@ -21,6 +21,7 @@ Add ``djangocms_stories`` and some dependent apps to your ``INSTALLED_APPS``::
 
     INSTALLED_APPS = [
         # ... other apps
+        'djangocms_text',
         'djangocms_stories',
         'parler',
         'taggit',


### PR DESCRIPTION
## Description

This PR updates the README to add the required `djangocms-text` dependency. It also updates related documentation pages to ensure consistency across the docs.

## Related resources
- #87

## Summary by Sourcery

Document the djangocms-text dependency across project documentation.

Documentation:
- Add the missing djangocms-text dependency to the main README.
- Align installation and migration guide documentation to mention the djangocms-text dependency consistently.