### PR TITLE
 fix: PostContent could return a lazy string instad of string

### DIFF
--- a/djangocms_stories/models.py
+++ b/djangocms_stories/models.py
@@ -742,7 +742,7 @@ class PostContent(PostMetaMixin, ModelMeta, models.Model):
         return ",".join(taglist)
 
     def __str__(self):
-        return self.title or _("Untitled")
+        return self.title or gettext("Untitled")
 
 
 class BasePostPlugin(CMSPlugin):

--- a/djangocms_stories/static/djangocms_stories/css/djangocms_stories_admin.css
+++ b/djangocms_stories/static/djangocms_stories/css/djangocms_stories_admin.css
@@ -19,7 +19,7 @@
     margin: 0;
 }
 
-form select {
+form .flex-container > select {
     max-width: 266px;
 }
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -240,7 +240,7 @@ def test_post_change_admin(admin_client, default_config, assert_html_in_response
     )
 
     # Both post and post content fields are present
-    if DJANGO_VERSION >= (6,0):
+    if DJANGO_VERSION >= (6,1):
         assert_html_in_response('<legend class="inline" for="id_author">Author:</legend>', response)  # Post author field
     else:
         assert_html_in_response('<label class="inline" for="id_author">Author:</label>', response)  # Post author field


### PR DESCRIPTION
## Summary by Sourcery

Ensure story titles are rendered as concrete strings and refine admin form styling for select elements.

Bug Fixes:
- Return a concrete translated string for untitled stories instead of a lazy translation object.
- Scope admin CSS so the max-width style only applies to select elements within flex-container forms.