### PR TITLE
chore: upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/migraton_test.yml
+++ b/.github/workflows/migraton_test.yml
@@ -21,9 +21,9 @@ jobs:
         ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,9 +40,9 @@ jobs:
           - requirements-file: "dj42_cms50.txt"
             python-version: "3.14"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -57,6 +57,6 @@ jobs:
         pytest --cov --cov-branch --cov-report=xml
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- upgrade outdated GitHub Actions versions listed in the repository audit
- align workflow action references with their current supported versions

## Testing
- not run (workflow-only change)

## Summary by Sourcery

Update GitHub Actions workflows to use the latest supported action versions.

CI:
- Bump actions/checkout to v6 in test and migration workflows.
- Upgrade actions/setup-python to v6 across test, migration, and publish workflows.
- Update Codecov upload step to use codecov/codecov-action v6.