### PR TITLE
fix: Ignored language when fetching a post content object

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,25 +12,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
         requirements-file: [
           dj42_cms41.txt,
           dj52_cms41.txt,
           dj42_cms50.txt,
           dj52_cms50.txt,
           dj60_cms50.txt,
+          dj52_cms51.txt,
+          dj60_cms51.txt,
         ]
         versioning: [ "on", "off" ]
         os: [
           ubuntu-latest,
         ]
         exclude:
-          - python-version: "3.10"
-            requirements-file: "dj52_cms41.txt"
-          - python-version: "3.10"
-            requirements-file: "dj60_cms50.txt"
           - python-version: "3.11"
             requirements-file: "dj60_cms50.txt"
+          - python-version: "3.11"
+            requirements-file: "dj60_cms51.txt"
           - requirements-file: "dj42_cms41.txt"
             versioning: "on"
           - requirements-file: "dj52_cms41.txt"

--- a/djangocms_stories/views.py
+++ b/djangocms_stories/views.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.timezone import now
-from django.utils.translation import get_language
+from django.utils.translation import get_language, get_language_from_request
 from django.views.generic import DetailView, ListView
 from parler.views import TranslatableSlugMixin, ViewUrlMixin
 
@@ -64,6 +64,9 @@ class PostDetailView(StoriesConfigMixin, DetailView):
         else:
             template_path = (self.config and self.config.template_prefix) or "djangocms_stories"
             return [os.path.join(template_path, self.base_template_name)]
+
+    def get_queryset(self):
+        return super().get_queryset().filter(language=get_language())
 
     def get_object(self):
         obj = super().get_object()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Framework :: Django :: 6.0",
   "Framework :: Django CMS :: 4.1",
   "Framework :: Django CMS :: 5.0",
+  "Framework :: Django CMS :: 5.1",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -39,13 +40,14 @@ dependencies = [
   "django-taggit>=1",
   "django-taggit-autosuggest",
   "django-taggit-templatetags",
+  "djangocms-text",
   "easy-thumbnails>=2.4.1",
   "lxml",
   "pytz",
 ]
 
 optional-dependencies.docs = [
-  "django<5",
+  "django",
 ]
 optional-dependencies.taggit-helpers = [
   "django-taggit-helpers",

--- a/tests/requirements/dj52_cms51.txt
+++ b/tests/requirements/dj52_cms51.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django~=5.2
+django-cms>=5.1.0a1,<5.2

--- a/tests/requirements/dj60_cms51.txt
+++ b/tests/requirements/dj60_cms51.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django>=6.0a1,<6.1
+django-cms>=5.1.0a1,<5.2

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,8 @@ import pytest
 from django.apps import apps
 from django.test import RequestFactory
 from django.urls import reverse
+from django.utils import translation
+from django.utils.timezone import now
 
 from djangocms_stories.cms_appconfig import get_app_instance
 
@@ -241,3 +243,68 @@ def test_post_category_list_view(client, default_config, assert_html_in_response
     for category in categories:
         assert_html_in_response(f'<section id="category-{category.slug}" class="category-item">', response)
         assert_html_in_response(f'<div class="category-header"><h3>{category.name}</h3></div>', response)
+
+
+@pytest.mark.django_db
+def test_post_detail_view_same_slug_different_languages(client, admin_user, default_config):
+    """
+    Two PostContent objects with the same slug but different languages
+    should each return the correct content for their respective language.
+    """
+    from djangocms_stories.models import Post
+
+    from .factories import PostContentFactory, UserFactory
+
+    post = Post.objects.create(
+        app_config=default_config,
+        author=UserFactory(),
+        date_published=now(),
+    )
+
+    en_content = PostContentFactory(
+        post=post,
+        language="en",
+        title="English Title",
+        subtitle="English Subtitle",
+        slug="shared-slug",
+        meta_title="English Meta Title",
+        meta_description="English meta description.",
+    )
+    fr_content = PostContentFactory(
+        post=post,
+        language="fr",
+        title="Titre Français",
+        subtitle="Sous-titre Français",
+        slug="shared-slug",
+        meta_title="Titre Méta Français",
+        meta_description="Description méta française.",
+    )
+
+    publish_if_necessary([en_content, fr_content], admin_user)
+
+    # Build URL using the post's date and the shared slug
+    date = post.date
+    url_kwargs = {
+        "year": date.year,
+        "month": "%02d" % date.month,
+        "day": "%02d" % date.day,
+        "slug": "shared-slug",
+    }
+
+    # Request the English version (reverse with 'en' language gives /en/blog/...)
+    with translation.override("en"):
+        en_url = reverse("djangocms_stories:post-detail", kwargs=url_kwargs)
+    en_response = client.get(en_url)
+    assert en_response.status_code == 200
+    en_body = en_response.content.decode("utf-8")
+    assert "English Title" in en_body
+    assert "Titre Français" not in en_body
+
+    # Request the French version
+    with translation.override("fr"):
+        fr_url = reverse("djangocms_stories:post-detail", kwargs=url_kwargs)
+    fr_response = client.get(fr_url)
+    assert fr_response.status_code == 200
+    fr_body = fr_response.content.decode("utf-8")
+    assert "Titre Français" in fr_body
+    assert "English Title" not in fr_body


### PR DESCRIPTION
## Summary by Sourcery

Ensure post detail views respect the current language when resolving post content and update project configuration for the latest supported Django CMS versions and dependencies.

Bug Fixes:
- Filter post detail queryset by the active language so posts with the same slug in different languages return the correct localized content.

Build:
- Declare compatibility with Django CMS 5.1 and add djangocms-text as a core dependency, while relaxing docs extra to support any Django version.

Tests:
- Add a regression test verifying that post detail requests return language-specific content when multiple translations share the same slug.

fixes #96 

* #96