### PR TITLE
fix: Avoid posts with date_published set to fall behind all without

### DIFF
--- a/djangocms_stories/feeds.py
+++ b/djangocms_stories/feeds.py
@@ -38,11 +38,9 @@ class LatestEntriesFeed(Feed):
         return _("Blog articles on %(site_name)s") % {"site_name": Site.objects.get_current().name}
 
     def items(self, obj=None):
-        return (
-            Post.objects.prefetch_related("postcontent_set")
-            .filter(app_config__namespace=self.namespace, include_in_rss=True)
-            .order_by("-date_published")[: self.feed_items_number]
-        )
+        return Post.objects.prefetch_related("postcontent_set").filter(
+            app_config__namespace=self.namespace, include_in_rss=True
+        )[: self.feed_items_number][: self.feed_items_number]
 
     def item_title(self, item):
         return mark_safe(item.safe_translation_getter("title"))

--- a/djangocms_stories/models.py
+++ b/djangocms_stories/models.py
@@ -11,6 +11,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.cache import cache
 from django.db import models
 from django.db.models import F, Q
+from django.db.models.functions import Coalesce
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django.urls import NoReverseMatch, reverse
@@ -392,7 +393,7 @@ class Post(models.Model):
     class Meta:
         verbose_name = _("post")
         verbose_name_plural = _("posts")
-        ordering = ("-date_published", "-date_created")
+        ordering = (Coalesce("date_published", "date_created").desc(), "-date_created")
         get_latest_by = "date_published"
 
     def __init__(self, *args, **kwargs):
@@ -603,8 +604,9 @@ class PostContent(PostMetaMixin, ModelMeta, models.Model):
     class Meta:
         verbose_name = _("post content")
         verbose_name_plural = _("post contents")
-        ordering = ("-post__date_published", "-post__date_created")
-        get_latest_by = "date_published"
+        # PostContent.Meta
+        ordering = (Coalesce(F("post__date_published"), F("post__date_created")).desc(), "-post__date_created")
+        get_latest_by = "post__date_published"
 
     # Gruping fields
     post = models.ForeignKey(Post, on_delete=models.CASCADE)

--- a/djangocms_stories/models.py
+++ b/djangocms_stories/models.py
@@ -604,9 +604,8 @@ class PostContent(PostMetaMixin, ModelMeta, models.Model):
     class Meta:
         verbose_name = _("post content")
         verbose_name_plural = _("post contents")
-        # PostContent.Meta
-        ordering = (Coalesce(F("post__date_published"), F("post__date_created")).desc(), "-post__date_created")
-        get_latest_by = "post__date_published"
+        ordering = ("post",)
+        get_latest_by = "post"
 
     # Gruping fields
     post = models.ForeignKey(Post, on_delete=models.CASCADE)


### PR DESCRIPTION
Use Coalesce("date_published", "date_created").desc() where possible, otherwise nulls_last=True.

## Summary by Sourcery

Adjust post and post content ordering to prioritize published dates while preventing published posts from being sorted behind unpublished ones.

Bug Fixes:
- Ensure posts and post contents with a published date are ordered correctly relative to those without in model defaults and RSS feeds.

Enhancements:
- Use database expressions for model and feed ordering to coalesce or place null published dates last.